### PR TITLE
Handle failures from procstat more gracefully

### DIFF
--- a/src/chericat.c
+++ b/src/chericat.c
@@ -150,11 +150,6 @@ main(int argc, char *argv[])
 			caps_syms_view(db, optarg);
 			break;
 		case 'd':
-			// First check if db exists
-			if (access(optarg, F_OK) != 0) {
-				fprintf(stderr, "db %s does not exist\n", optarg);
-				exit(1);
-			}
 			dbname = (char*)malloc(strlen(optarg)+1);
 			strcpy(dbname, optarg);
 			break;

--- a/src/db_process.c
+++ b/src/db_process.c
@@ -95,6 +95,13 @@ int db_table_exists(sqlite3 *db, char *tname)
 	return exists;
 }
 
+	
+#define assert_db_table_exists(db, tname) {\
+	if (0 == db_table_exists(db, tname)) {\
+		errx(1, "%s table does not exist on db %s", tname, dbname);\
+	}\
+}
+
 /*
  * create_vm_cap_db
  * Creates two tables, one for the VM entries and the other one contains all the 
@@ -350,10 +357,8 @@ static int sym_info_count_query_callback(void *count, int argc, char **argv, cha
 
 int vm_info_count(sqlite3 *db) 
 {
-	// First check if the vm table exists
-	if (0 == db_table_exists(db, "vm")) {
-		errx(1, "vm table does not exist on db %s", dbname);
-	}
+
+	assert_db_table_exists(db, "vm");
 
         /* Obtain how many vm items from the database first, we can then use it to
          * determine the size of the struct array for holding all the vm entries */
@@ -367,10 +372,11 @@ int vm_info_count(sqlite3 *db)
 
 int cap_info_count(sqlite3 *db)
 {
-	// First check if the vm table exists
+	/*
 	if (0 == db_table_exists(db, "cap_info")) {
 		errx(1, "cap_info table does not exist on db %s", dbname);
-	}
+	}*/
+	assert_db_table_exists(db, "cap_info");
 
         /* Obtain how many vm items from the database first, we can then use it to
          * determine the size of the struct array for holding all the vm entries */
@@ -384,10 +390,11 @@ int cap_info_count(sqlite3 *db)
 
 int sym_info_count(sqlite3 *db)
 {
-	// First check if the vm table exists
+	/*
 	if (0 == db_table_exists(db, "elf_sym")) {
 		errx(1, "elf_sym table does not exist on db %s", dbname);
-	}
+	}*/
+	assert_db_table_exists(db, "elf_sym");
 
         /* Obtain how many vm items from the database first, we can then use it to
          * determine the size of the struct array for holding all the vm entries */
@@ -400,11 +407,12 @@ int sym_info_count(sqlite3 *db)
 }
 
 int cap_info_for_lib_count(sqlite3 *db, char *lib)
-{       
-	// First check if the vm table exists
+{      
+        /*	
 	if (0 == db_table_exists(db, "cap_info")) {
 		errx(1, "cap_info table does not exist on db %s", dbname);
-	}
+	}*/
+	assert_db_table_exists(db, "cap_info");
 
         /* Obtain how many vm items from the database first, we can then use it to
          * determine the size of the struct array for holding all the vm entries */
@@ -422,10 +430,11 @@ int cap_info_for_lib_count(sqlite3 *db, char *lib)
 
 int get_all_vm_info(sqlite3 *db, vm_info **all_vm_info_ptr)
 {
-	// First check if the vm table exists
+	/*
 	if (0 == db_table_exists(db, "vm")) {
 		errx(1, "vm table does not exist on db %s", dbname);
-	}
+	}*/
+	assert_db_table_exists(db, "vm");
 
 	int vm_count = vm_info_count(db);
         *all_vm_info_ptr = (vm_info *)calloc(vm_count, sizeof(vm_info));
@@ -442,11 +451,11 @@ int get_all_vm_info(sqlite3 *db, vm_info **all_vm_info_ptr)
 
 int get_all_cap_info(sqlite3 *db, cap_info **all_cap_info_ptr)
 {
-	// First check if the vm table exists
+	/*
 	if (0 == db_table_exists(db, "cap_info")) {
 		errx(1, "cap_info table does not exist on db %s", dbname);
-	}
-
+	}*/
+	assert_db_table_exists(db, "cap_info");
 
 	int cap_count = cap_info_count(db);
         *all_cap_info_ptr = (cap_info *)calloc(cap_count, sizeof(cap_info));
@@ -463,10 +472,11 @@ int get_all_cap_info(sqlite3 *db, cap_info **all_cap_info_ptr)
 
 int get_all_sym_info(sqlite3 *db, sym_info **all_sym_info_ptr)
 {
-	// First check if the vm table exists
+	/*
 	if (0 == db_table_exists(db, "elf_sym")) {
 		errx(1, "elf_sym table does not exist on db %s", dbname);
-	}
+	}*/
+	assert_db_table_exists(db, "elf_sym");
 
 	int sym_count = sym_info_count(db);
         *all_sym_info_ptr = (sym_info *)calloc(sym_count, sizeof(sym_info));
@@ -483,10 +493,11 @@ int get_all_sym_info(sqlite3 *db, sym_info **all_sym_info_ptr)
 
 int get_cap_info_for_lib(sqlite3 *db, cap_info **cap_info_captured_ptr, char *lib)
 {
-	// First check if the vm table exists
+	/*
 	if (0 == db_table_exists(db, "cap_info")) {
 		errx(1, "cap_info table does not exist on db %s", dbname);
-	}
+	}*/
+	assert_db_table_exists(db, "cap_info");
 
 	int cap_count = cap_info_for_lib_count(db, lib);
 	*cap_info_captured_ptr = (cap_info *)calloc(cap_count, sizeof(cap_info));

--- a/src/mem_scan.c
+++ b/src/mem_scan.c
@@ -79,15 +79,15 @@ void scan_mem(sqlite3 *db, char* arg_pid)
 
 	kipp = procstat_getprocs(psp, KERN_PROC_PID, pid, &pcnt);
 	if (kipp == NULL) {
-		errx(1, "Unable to attach to process with pid %d, does it exist?\n", pid);
+		errx(1, "Unable to attach to process with pid %d, does it exist?", pid);
 	}
 	if (pcnt != 1) {
-		errx(1, "procstat did not get expected result from process %d\n", pid);
+		errx(1, "procstat did not get expected result from process %d", pid);
 	}
 
 	freep = procstat_getvmmap(psp, kipp, &vmcnt);
 	if (freep == NULL) {
-		errx(1, "Unable to obtain the vm map information from process %d, does cherciat have the right privilege?\n", pid);
+		errx(1, "Unable to obtain the vm map information from process %d, does cherciat have the right privilege?", pid);
 	}
 
 	create_vm_cap_db(db);

--- a/src/mem_scan.c
+++ b/src/mem_scan.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <err.h>
 #include <errno.h>
 #include <string.h>
 #include <sqlite3.h>
@@ -78,18 +79,15 @@ void scan_mem(sqlite3 *db, char* arg_pid)
 
 	kipp = procstat_getprocs(psp, KERN_PROC_PID, pid, &pcnt);
 	if (kipp == NULL) {
-		fprintf(stderr, "Unable to attach to process with pid %d, does it exist?\n", pid);
-		exit(1);
+		errx(1, "Unable to attach to process with pid %d, does it exist?\n", pid);
 	}
 	if (pcnt != 1) {
-		fprintf(stderr, "procstat did not get expected result from process %d\n", pid);
-		exit(1);
+		errx(1, "procstat did not get expected result from process %d\n", pid);
 	}
 
 	freep = procstat_getvmmap(psp, kipp, &vmcnt);
 	if (freep == NULL) {
-		fprintf(stderr, "Unable to obtain the vm map information from process %d, does cherciat have the right privilege?\n", pid);
-		exit(1);
+		errx(1, "Unable to obtain the vm map information from process %d, does cherciat have the right privilege?\n", pid);
 	}
 
 	create_vm_cap_db(db);

--- a/src/mem_scan.c
+++ b/src/mem_scan.c
@@ -77,11 +77,20 @@ void scan_mem(sqlite3 *db, char* arg_pid)
 	assert(psp != NULL);
 
 	kipp = procstat_getprocs(psp, KERN_PROC_PID, pid, &pcnt);
-	assert(kipp != NULL);
-	assert(pcnt == 1);
+	if (kipp == NULL) {
+		fprintf(stderr, "Unable to attach to process with pid %d, does it exist?\n", pid);
+		exit(1);
+	}
+	if (pcnt != 1) {
+		fprintf(stderr, "procstat did not get expected result from process %d\n", pid);
+		exit(1);
+	}
 
 	freep = procstat_getvmmap(psp, kipp, &vmcnt);
-	assert(freep != NULL);
+	if (freep == NULL) {
+		fprintf(stderr, "Unable to obtain the vm map information from process %d, does cherciat have the right privilege?\n", pid);
+		exit(1);
+	}
 
 	create_vm_cap_db(db);
 	debug_print(TROUBLESHOOT, "Key Stage: Attach process %d using ptrace\n", pid);


### PR DESCRIPTION
Previous code uses assertion, which would cause a system abort with core dump, which is too dramatic for simple error cases such as process doesn't exist.