### PR TITLE
Grow the kivp array size dynamically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ CFLAGS+=-g -O0
 CFLAGS+=-Wall -Wcheri
 
 SRC_BASE?=/usr/src
+ARCH+=aarch64
 INC=-I/usr/include -I/usr/local/include -I$(DEPS) -I${SRC_BASE}/libexec/rtld-elf -I${SRC_BASE}/libexec/rtld-elf/${ARCH}
 LDFLAGS=-L/usr/lib -L/usr/local/lib 
 

--- a/includes/rtld_linkmap_scan.h
+++ b/includes/rtld_linkmap_scan.h
@@ -33,7 +33,6 @@
 #define RTLD_LINKMAP_SCAN_H_
 
 #include <sqlite3.h>
-#define __CHERI_PURE_CAPABILITY__
 
 typedef struct struct_compart_data_t {
 	int id;

--- a/src/mem_scan.c
+++ b/src/mem_scan.c
@@ -124,8 +124,7 @@ void scan_mem(sqlite3 *db, int pid)
 	size_t seen_kivp_buffer_capacity;
 	struct kinfo_vmentry *seen_kivp;
 
-	int initial_size = 100;
-	int growth_size = 100;
+	const int initial_size = 100;
 	seen_kivp_buffer_size = 0;
 	seen_kivp_buffer_capacity = initial_size;
 	seen_kivp = calloc(initial_size, sizeof(struct kinfo_vmentry));
@@ -155,7 +154,7 @@ void scan_mem(sqlite3 *db, int pid)
 
 			if (!seen) {
 				if (seen_kivp_buffer_size == seen_kivp_buffer_capacity) {
-					seen_kivp_buffer_capacity = seen_kivp_buffer_capacity + growth_size;
+					seen_kivp_buffer_capacity <<= 1;
 					seen_kivp = realloc(seen_kivp, seen_kivp_buffer_capacity*sizeof(struct kinfo_vmentry));
 					if (!seen_kivp) {
 						errx(1, "Out of memory, cannot grow the size of the kivp array any more, current size is: %lu", seen_kivp_buffer_size);

--- a/src/mem_scan.c
+++ b/src/mem_scan.c
@@ -131,6 +131,7 @@ void scan_mem(sqlite3 *db, int pid)
 		errx(1, "Cannot allocate %lu bytes for the kivp array container", sizeof(seen_kivp_wrapper_struct));
 	}
 	int initial_size = 100;
+	int growth_size = 100;
 	seen_kivp_wrapper->size = 0;
 	seen_kivp_wrapper->capacity = initial_size;
 	seen_kivp_wrapper->seen_kivp = calloc(initial_size, sizeof(struct kinfo_vmentry));
@@ -161,10 +162,10 @@ void scan_mem(sqlite3 *db, int pid)
 			if (!seen) {
 				if (seen_kivp_wrapper->size == seen_kivp_wrapper->capacity) {
 					struct kinfo_vmentry *temp = seen_kivp_wrapper->seen_kivp;
-					seen_kivp_wrapper->capacity <<= 1;
+					seen_kivp_wrapper->capacity = seen_kivp_wrapper->capacity + growth_size;
 					seen_kivp_wrapper->seen_kivp = realloc(seen_kivp_wrapper->seen_kivp, seen_kivp_wrapper->capacity*sizeof(struct kinfo_vmentry));
 					if (!seen_kivp_wrapper->seen_kivp) {
-						errx(1, "Cannot grow the size of the kivp array");
+						errx(1, "Out of memory, cannot grow the size of the kivp array any more, current size is: %lu", seen_kivp_wrapper->size);
 						seen_kivp_wrapper->seen_kivp = temp;
 					}
 				}				

--- a/src/mem_scan.c
+++ b/src/mem_scan.c
@@ -154,7 +154,7 @@ void scan_mem(sqlite3 *db, int pid)
 
 			if (!seen) {
 				if (seen_kivp_buffer_size == seen_kivp_buffer_capacity) {
-					seen_kivp_buffer_capacity <<= 1;
+					seen_kivp_buffer_capacity *= 2;
 					seen_kivp = realloc(seen_kivp, seen_kivp_buffer_capacity*sizeof(struct kinfo_vmentry));
 					if (!seen_kivp) {
 						errx(1, "Out of memory, cannot grow the size of the kivp array any more, current size is: %lu", seen_kivp_buffer_size);

--- a/src/rtld_linkmap_scan.c
+++ b/src/rtld_linkmap_scan.c
@@ -29,7 +29,6 @@
  * SUCH DAMAGE.
  */
 
-#define __CHERI_PURE_CAPABILITY__
 #define RTLD_SANDBOX
 
 #include <stdio.h>

--- a/tests/db_process_test.c
+++ b/tests/db_process_test.c
@@ -226,8 +226,8 @@ int all_vm_info_index, all_cap_info_index, all_sym_info_index;
  */
 static int vm_info_query_callback(void *all_vm_info_ptr, int argc, char **argv, char **azColName)
 {
-        /* Database schema for vm has 13 columns */
-        assert(argc == 13);
+        /* Database schema for vm has 11 columns */
+        assert(argc == 11);
  
         vm_info vm_info_captured;
         vm_info_captured.start_addr = strdup(argv[0]);
@@ -238,12 +238,10 @@ static int vm_info_query_callback(void *all_vm_info_ptr, int argc, char **argv, 
      	vm_info_captured.mmap_flags = atoi(argv[5]); 
         vm_info_captured.vnode_type = atoi(argv[6]);
 
-	vm_info_captured.bss_addr = argv[7] == NULL ? NULL : strdup(argv[7]);
-        vm_info_captured.bss_size = argv[8] == NULL ? NULL : strdup(argv[8]);
-        vm_info_captured.plt_addr = argv[9] == NULL ? NULL : strdup(argv[9]);
-        vm_info_captured.plt_size = argv[10] == NULL ? NULL : strdup(argv[10]);
-        vm_info_captured.got_addr = argv[11] == NULL ? NULL : strdup(argv[11]);
-        vm_info_captured.got_size = argv[12] == NULL ? NULL : strdup(argv[12]);
+        vm_info_captured.plt_addr = argv[7] == NULL ? NULL : strdup(argv[7]);
+        vm_info_captured.plt_size = argv[8] == NULL ? NULL : strdup(argv[8]);
+        vm_info_captured.got_addr = argv[9] == NULL ? NULL : strdup(argv[9]);
+        vm_info_captured.got_size = argv[10] == NULL ? NULL : strdup(argv[10]);
 
 	vm_info **result_ptr = (vm_info **)all_vm_info_ptr;
        	(*result_ptr)[all_vm_info_index++] = vm_info_captured;


### PR DESCRIPTION
 During vm scan, an array buffer is used to keep track the memory block/file path that has been scanned already, this array used a fixed size which could cause chericat to crash if the size is not big enough. This PR is to fix this by enabling the array size to increase by 100 each time when the size limit has been reached.

If there is not enough memory to create the bigger array size, chericat would exit with an error saying out of memory.