### PR TITLE
Register signal handler in chericat main

### DIFF
--- a/src/chericat.c
+++ b/src/chericat.c
@@ -107,7 +107,6 @@ void terminate_chericat(int sig)
 	exit(sig);
 }
 
-
 int 
 main(int argc, char *argv[])
 {
@@ -148,7 +147,6 @@ main(int argc, char *argv[])
 			char *pEnd;
 			pid = strtol(optarg, &pEnd, 10);
 
-			
 			if (*pEnd != '\0') {
 				errx(1, "%s is not a valid pid", optarg);
 			}

--- a/src/chericat.c
+++ b/src/chericat.c
@@ -126,22 +126,10 @@ main(int argc, char *argv[])
 	static int debug_level = 0;
 	set_print_level(debug_level);
 
-#ifdef HAVE_SIGACTION
-{
-	struct sigaction sa;
-	sa.sa_flags=0;
-	sa.sa_handler = sigterm;
-	sigaction(SIGINT, &sa, NULL);
-	sigaction(SIGTERM, &sa, NULL);
-	sigaction(SIGPIPE, &sa, NULL);
-	sigaction(SIGQUIT, &sa, NULL);
-}
-#else
 	signal(SIGTERM, terminate_chericat);
 	signal(SIGINT, terminate_chericat);
 	signal(SIGPIPE, SIG_IGN);
 	signal(SIGQUIT, terminate_chericat);
-#endif
 
 	while (opt != -1) {
 		switch (opt)

--- a/src/ptrace_utils.c
+++ b/src/ptrace_utils.c
@@ -33,7 +33,6 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <errno.h>
 #include <string.h>
 #include <libelf.h>

--- a/src/ptrace_utils.c
+++ b/src/ptrace_utils.c
@@ -56,8 +56,6 @@
 #include "common.h"
 #include "db_process.h"
 
-bool attached=false;
-
 /*
  * ptrace_attach(int pid)
  * Calls the ptrace API to remotely attach a running process that has
@@ -80,7 +78,6 @@ void ptrace_attach(int pid)
                 fprintf(stderr, "ptrace waitpid failed: %s %d\n", strerror(err_waitpid), err_waitpid);
                 return;
         }
-	attached = true;
 }
 
 /*
@@ -91,12 +88,11 @@ void ptrace_attach(int pid)
  */
 void ptrace_detach(int pid)
 {
-        if (attached == true && ptrace(PT_DETACH, pid, 0, 0) == -1) {
+        if (ptrace(PT_DETACH, pid, 0, 0) == -1) {
                 int err_detach = errno;
                 fprintf(stderr, "ptrace detach failed: %s %d\n", strerror(err_detach), err_detach);
                 return;
         }
-	attached = false;
 }
 
 void print_ptype(size_t pt) {

--- a/src/ptrace_utils.c
+++ b/src/ptrace_utils.c
@@ -33,6 +33,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <errno.h>
 #include <string.h>
 #include <libelf.h>
@@ -54,6 +55,8 @@
 
 #include "common.h"
 #include "db_process.h"
+
+bool attached=false;
 
 /*
  * ptrace_attach(int pid)
@@ -77,6 +80,7 @@ void ptrace_attach(int pid)
                 fprintf(stderr, "ptrace waitpid failed: %s %d\n", strerror(err_waitpid), err_waitpid);
                 return;
         }
+	attached = true;
 }
 
 /*
@@ -87,11 +91,12 @@ void ptrace_attach(int pid)
  */
 void ptrace_detach(int pid)
 {
-        if (ptrace(PT_DETACH, pid, 0, 0) == -1) {
+        if (attached == true && ptrace(PT_DETACH, pid, 0, 0) == -1) {
                 int err_detach = errno;
                 fprintf(stderr, "ptrace detach failed: %s %d\n", strerror(err_detach), err_detach);
                 return;
         }
+	attached = false;
 }
 
 void print_ptype(size_t pt) {


### PR DESCRIPTION
If Chericat is attached to a target process when a terminating signal is received, it could kill the target process which is undesirable given that the signal is to terminate Chericat. Adding a signal handler would enable the chericat process to handle the signal and exit gracefully, without affecting the target process.