### PR TITLE
Tidier commandline options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 bin/
+src/*.o
+*.out
 *.db
 *.sql
 *.elf
 *.core
+*dump
 .DS_Store
-tests/test
 python/__pycache__
 python/graph-output
 python/.ipynb_checkpoints

--- a/includes/chericat.h
+++ b/includes/chericat.h
@@ -1,0 +1,10 @@
+#ifndef __CHERICAT_H__
+#define __CHERICAT_H__
+
+#define CHERICAT_DEBUG         0x0001
+#define CHERICAT_DB            0x0002
+#define CHERICAT_PID           0x0004
+#define CHERICAT_SUMMARY_VIEW  0x0008
+#define CHERICAT_CAP_INFO      0x0010
+
+#endif /* !__CHERICAT__ */

--- a/src/chericat.c
+++ b/src/chericat.c
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
     if (opt_i > 0) {
 	// There should only be and exactly one of the l and c options provided for the -v option.
 	if ((opt_l == 0 && opt_c == 0) || (opt_l > 0 && opt_c > 0)) {
-	    exit_usage("-v requires either -l (library view) or -c (compartment view) first");
+	    exit_usage("-i requires either -l (library view) or -c (compartment view) first");
 	}
 	if (db == NULL) {
 	    int rc = sqlite3_open(get_dbname(), &db);

--- a/src/db_process.c
+++ b/src/db_process.c
@@ -457,6 +457,9 @@ int get_all_vm_info(sqlite3 *db, vm_info **all_vm_info_ptr)
         
         int rc = sql_query_exec(db, "SELECT * FROM vm;", vm_info_query_callback, all_vm_info_ptr);
 
+	// reset all_vm_info_index
+	all_vm_info_index = 0;
+
 	if (rc == 0) {
 		return vm_count;
 	} else {
@@ -474,6 +477,9 @@ int get_all_cap_info(sqlite3 *db, cap_info **all_cap_info_ptr)
         
         int rc = sql_query_exec(db, "SELECT * FROM cap_info;", cap_info_query_callback, all_cap_info_ptr);
 
+	// reset the all_cap_info_index
+	all_cap_info_index = 0;
+	
 	if (rc == 0) {
 		return cap_count;
 	} else {
@@ -490,6 +496,9 @@ int get_all_sym_info(sqlite3 *db, sym_info **all_sym_info_ptr)
         assert (*all_sym_info_ptr != NULL);
         
         int rc = sql_query_exec(db, "SELECT * FROM elf_sym;", sym_info_query_callback, all_sym_info_ptr);
+	
+	// reset all_sym_info_index
+	all_sym_info_index = 0;
 
 	if (rc == 0) {
 		return sym_count;
@@ -511,6 +520,8 @@ int get_cap_info_for_lib(sqlite3 *db, cap_info **cap_info_captured_ptr, char *li
 	int rc = sql_query_exec(db, query, cap_info_query_callback, cap_info_captured_ptr);
 
 	free(query);
+	// reset all_cap_info_index
+	all_cap_info_index = 0;
 
 	if (rc == 0) {
 		return cap_count;

--- a/tests/cmdline_opts_test.sh
+++ b/tests/cmdline_opts_test.sh
@@ -58,80 +58,67 @@ else
 fi
 
 ########
-# Test that chericat with -v without -l or -c would result in an error message
+# Test that chericat with -v without show lib or show comp command would result in an error message
 ########
 pass=0
 output=$($bin -v 2>&1)
-echo "$output" | grep -q "\-v requires either \-l (library view) or \-c (compartment view)" -
+echo "$output" | grep -q "Expecting \"show lib|comp\" command after the options" -
 if [ $? == 0 ]; then 
     pass=1
 else
-    echo "Unexpected result for -v without specifying -l or -c"
+    echo "Unexpected result for -v without specifying show lib or show comp commands"
     exit 1
 fi
 
 ########
-# Test that chericat with -lv without -f or -p option would result in an error message
+# Test that chericat with -v without -f or -p option would result in an error message
 ########
 pass=0
-output=$($bin -lv 2>&1)
+output=$($bin -v show lib 2>&1)
 echo "$output" | grep -q "vm table does not exist on db" -
 if [ $? == 0 ]; then 
     pass=1
 else
-    echo "Unexpected result for -lv without -f or -p"
+    echo "Unexpected result for -v show lib without -f or -p"
     exit 1
 fi
 
 ########
-# Test that chericat with -i <name> without -l or -c would result in an error message
+# Test that chericat with -i <name> without show lib or show comp command would result in an error message
 ########
 pass=0
 output=$($bin -i "somename" 2>&1)
-echo "$output" | grep -q "\-i requires either \-l (library view) or \-c (compartment view)" -
+echo "$output" | grep -q "Expecting \"show lib|comp\" command after the options" -
 if [ $? == 0 ]; then 
     pass=1
 else
-    echo "Unexpected result for -i <name> without specifying -l or -c"
+    echo "Unexpected result for -i <name> without specifying show lib or show comp"
     exit 1
 fi
 
 ########
-# Test that chericat with -li without the library name would result in an error message
+# Test that chericat with -i without the library or compartment name would result in an error message
 ########
 pass=0
-output=$($bin -li 2>&1)
+output=$($bin -i 2>&1)
 echo "$output" | grep -q "requires an argument" -
 if [ $? == 0 ]; then 
     pass=1
 else
-    echo "Unexpected result for -li with no input"
+    echo "Unexpected result for -i with no input"
     exit 1
 fi
 
 ########
-# Test that chericat with -li <library name> without -f or -p option would result in an error message
+# Test that chericat with -i <library name> show lib|comp without -f or -p option would result in an error message
 ########
 pass=0
-output=$($bin -li some_library 2>&1)
+output=$($bin -i some_library show lib 2>&1)
 echo "$output" | grep -q "cap_info table does not exist on db" -
 if [ $? == 0 ]; then 
     pass=1
 else
-    echo "Unexpected result for -li <library name> without -f or -p"
-    exit 1
-fi
-
-########
-# Test that chericat with -ci without the compartment name would result in an error message
-########
-pass=0
-output=$($bin -ci 2>&1)
-echo "$output" | grep -q "requires an argument" -
-if [ $? == 0 ]; then 
-    pass=1
-else
-    echo "Unexpected result for -ci with no input"
+    echo "Unexpected result for -i <library name> without -f or -p"
     exit 1
 fi
 
@@ -152,7 +139,7 @@ fi
 # Test that chericat with -f with an invalid database name together with -v option would result in an error message
 ########
 pass=0
-output=$($bin -f invalid -lv 2>&1)
+output=$($bin -f invalid -v show lib 2>&1)
 echo "$output" | grep -q "vm table does not exist" -
 if [ $? == 0 ]; then 
     pass=1
@@ -165,7 +152,7 @@ fi
 # Test that chericat with -f with an invalid database name together with -i option would result in an error message
 ########
 pass=0
-output=$($bin -f invalid -li some_library 2>&1)
+output=$($bin -f invalid -i some_library show lib 2>&1)
 echo "$output" | grep -q "cap_info table does not exist" -
 if [ $? == 0 ]; then 
     pass=1

--- a/tests/cmdline_opts_test.sh
+++ b/tests/cmdline_opts_test.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+
+bindir="../bin"
+bin=$bindir"/chericat"
+
+########
+# Test that chericat with an invalid argument would output an error message
+########
+pass=0
+output=$($bin -z 2>&1)
+echo "$output" | grep -q 'invalid option' -
+
+if [ $? == 0 ]; then
+    pass=1
+else 
+    echo "Unexpected result for passing in an invalid option"
+    exit 1
+fi
+
+########
+# Test that chericat without input would output usage text
+########
+pass=0
+output=$($bin 2>&1)
+echo "$output" | grep -q 'Usage' -
+
+if [ $? == 0 ]; then
+    pass=1
+else 
+    echo "Unexpected result for no input"
+    exit 1
+fi
+
+########
+# Test that chericat with -f without a filename would result in an error message
+########
+pass=0
+output=$($bin -f 2>&1)
+echo "$output" | grep -q 'requires an argument' -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -f with no input"
+    exit 1
+fi
+
+########
+# Test that chericat with -p without a pid would result in an error message
+########
+pass=0
+output=$($bin -p 2>&1)
+echo "$output" | grep -q 'requires an argument' -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -p with no input"
+    exit 1
+fi
+
+########
+# Test that chericat with -v without -l or -c would result in an error message
+########
+pass=0
+output=$($bin -v 2>&1)
+echo "$output" | grep -q "\-v requires either \-l (library view) or \-c (compartment view)" -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -v without specifying -l or -c"
+    exit 1
+fi
+
+########
+# Test that chericat with -lv without -f or -p option would result in an error message
+########
+pass=0
+output=$($bin -lv 2>&1)
+echo "$output" | grep -q "vm table does not exist on db" -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -lv without -f or -p"
+    exit 1
+fi
+
+########
+# Test that chericat with -i <name> without -l or -c would result in an error message
+########
+pass=0
+output=$($bin -i "somename" 2>&1)
+echo "$output" | grep -q "\-i requires either \-l (library view) or \-c (compartment view)" -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -i <name> without specifying -l or -c"
+    exit 1
+fi
+
+########
+# Test that chericat with -li without the library name would result in an error message
+########
+pass=0
+output=$($bin -li 2>&1)
+echo "$output" | grep -q "requires an argument" -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -li with no input"
+    exit 1
+fi
+
+########
+# Test that chericat with -li <library name> without -f or -p option would result in an error message
+########
+pass=0
+output=$($bin -li some_library 2>&1)
+echo "$output" | grep -q "cap_info table does not exist on db" -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -li <library name> without -f or -p"
+    exit 1
+fi
+
+########
+# Test that chericat with -ci without the compartment name would result in an error message
+########
+pass=0
+output=$($bin -ci 2>&1)
+echo "$output" | grep -q "requires an argument" -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -ci with no input"
+    exit 1
+fi
+
+########
+# Test that chericat with -p with an invalid pid would result in an error message
+########
+pass=0
+output=$($bin -p 123 2>&1)
+echo "$output" | grep -q "No such process" -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -p with an invalid pid"
+    exit 1
+fi
+
+########
+# Test that chericat with -f with an invalid database name together with -v option would result in an error message
+########
+pass=0
+output=$($bin -f invalid -lv 2>&1)
+echo "$output" | grep -q "vm table does not exist" -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -f with an invalid database name, along with the -v option"
+    exit 1
+fi
+
+########
+# Test that chericat with -f with an invalid database name together with -i option would result in an error message
+########
+pass=0
+output=$($bin -f invalid -li some_library 2>&1)
+echo "$output" | grep -q "cap_info table does not exist" -
+if [ $? == 0 ]; then 
+    pass=1
+else
+    echo "Unexpected result for -f with an invalid database name, along with the -i option"
+    exit 1
+fi
+
+########
+# Check overall test status
+#########
+if [ $pass == 1 ]; then
+    echo "Test OK!"
+else
+    echo "Test FAIL"
+fi
+
+########
+# Clean up
+#########
+rm invalid
+
+exit 0


### PR DESCRIPTION
Separating the "library view" and "compartment view" for chericat by adding a conditional option -l and -c to go along with the -v (overview) and -i (capability info) options. Refactored to tidy up the main function code and to allow this feature, and fixed an issue with multiple options used together (e.g. when -v and -i were used together, the expected result would print out both the overview table and the capability info table, but the bug caused it to crash, now fixed).