### PR TITLE
Using bsd.prog.mk to simplify Makefile and added PREFIX to allow port…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 bin/
 src/*.o
+.depend*
+chericat
+chericat.1*
+chericat.full
+chericat.debug
 *.out
 *.db
 *.sql

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
-src/*.o
+*.o
+**/*.o
 .depend*
 chericat
 chericat.1*

--- a/Makefile
+++ b/Makefile
@@ -1,62 +1,14 @@
-BIN=./bin
-SRC=./src
-DEPS=./includes
+PROG= chericat
+MAN=  chericat.1
+SRCS= src/cap_capture.c src/caps_syms_view.c src/chericat.c src/common.c src/db_process.c src/elf_utils.c src/mem_scan.c src/ptrace_utils.c src/rtld_linkmap_scan.c src/vm_caps_view.c
 
-CC?=cc
-CFLAGS+=-g -O0
-CFLAGS+=-Wall -Wcheri
-CFLAGS+=-DIN_RTLD -DCHERI_LIB_C18N -DRTLD_SANDBOX
+PREFIX?=     /usr/local
+SRC_BASE?=   /usr/src
+ARCH?=       aarch64
+LDADD+=      -lelf -lprocstat -lsqlite3 -lxo 
 
-SRC_BASE?=/usr/src
-ARCH+=aarch64
-INC=-I/usr/include -I/usr/local/include -I$(DEPS) -I${SRC_BASE}/libexec/rtld-elf -I${SRC_BASE}/libexec/rtld-elf/${ARCH}
-LDFLAGS=-L/usr/lib -L/usr/local/lib 
+.if !defined(LOCALBASE)
+CFLAGS+=     -I${PREFIX}/include -I./includes -I${SRC_BASE}/libexec/rtld-elf -I${SRC_BASE}/libexec/rtld-elf/${ARCH} -L${PREFIX}/lib -DIN_RTLD -DCHERI_LIB_C18N
+.endif
 
-.PHONY: all
-.PHONY: make_dir
-.PHONY: clean
-
-TARGET=$(BIN)/chericat
-all: make_dir $(TARGET)
-
-make_dir: $(BIN)/
-
-$(BIN)/:
-	mkdir -p $@
-
-$(TARGET): $(SRC)/chericat.c $(BIN)/common.o $(BIN)/mem_scan.o $(BIN)/db_process.o $(BIN)/cap_capture.o $(BIN)/elf_utils.o $(BIN)/ptrace_utils.o $(BIN)/vm_caps_view.o $(BIN)/caps_syms_view.o $(BIN)/rtld_linkmap_scan.o
-	$(CC) $(CFLAGS) $(INC) $(LDFLAGS) -DSQLITE_MEMDEBUG -lelf -lprocstat -lsqlite3 -lxo -o $(TARGET) $(BIN)/common.o $(BIN)/mem_scan.o $(BIN)/elf_utils.o $(BIN)/ptrace_utils.o $(BIN)/cap_capture.o $(BIN)/db_process.o $(BIN)/vm_caps_view.o $(BIN)/caps_syms_view.o $(BIN)/rtld_linkmap_scan.o $(SRC)/chericat.c
-
-$(BIN)/common.o: $(SRC)/common.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/common.o $(SRC)/common.c
-$(BIN)/mem_scan.o: $(SRC)/mem_scan.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/mem_scan.o $(SRC)/mem_scan.c
-
-$(BIN)/ptrace_utils.o: $(SRC)/ptrace_utils.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/ptrace_utils.o $(SRC)/ptrace_utils.c
-
-$(BIN)/elf_utils.o: $(SRC)/elf_utils.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/elf_utils.o $(SRC)/elf_utils.c
-
-$(BIN)/db_process.o: $(SRC)/db_process.c $(DEPS)/db_process.h
-	$(CC) $(CFLAGS) $(INC) -DSQLITE_MEMDEBUG -c -o $(BIN)/db_process.o $(SRC)/db_process.c
-
-$(BIN)/cap_capture.o: $(SRC)/cap_capture.c $(DEPS)/cap_capture.h
-	$(CC) $(CFLAGS) $(INC) -DSQLITE_MEMDEBUG -c -o $(BIN)/cap_capture.o $(SRC)/cap_capture.c
-
-$(BIN)/vm_caps_view.o: $(SRC)/vm_caps_view.c $(DEPS)/vm_caps_view.h
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/vm_caps_view.o $(SRC)/vm_caps_view.c
-
-$(BIN)/caps_syms_view.o: $(SRC)/caps_syms_view.c $(DEPS)/caps_syms_view.h
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/caps_syms_view.o $(SRC)/caps_syms_view.c
-
-$(BIN)/rtld_linkmap_scan.o: $(SRC)/rtld_linkmap_scan.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/rtld_linkmap_scan.o $(SRC)/rtld_linkmap_scan.c
-
-TEST=./tests
-
-test: $(TEST)/db_process_test.c $(BIN)/common.o
-	$(CC) $(CFLAGS) $(INC) $(LDFLAGS) -DSQLITE_MEMDEBUG -lsqlite3 -o $(TARGET) $(BIN)/common.o $(TEST)/db_process_test.c -o $(BIN)/db_process_test
-
-clean:
-	rm -rf $(BIN)/*.o $(BIN)/chericat
+.include <bsd.prog.mk>

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PROG= chericat
 MAN=  chericat.1
-SRCS= src/cap_capture.c src/caps_syms_view.c src/chericat.c src/common.c src/db_process.c src/elf_utils.c src/mem_scan.c src/ptrace_utils.c src/rtld_linkmap_scan.c src/vm_caps_view.c
+.PATH: ${.CURDIR}/src
+SRCS= cap_capture.c caps_syms_view.c chericat.c common.c db_process.c elf_utils.c mem_scan.c ptrace_utils.c rtld_linkmap_scan.c vm_caps_view.c
 
 PREFIX?=     /usr/local
 SRC_BASE?=   /usr/src

--- a/src/rtld_linkmap_scan.c
+++ b/src/rtld_linkmap_scan.c
@@ -247,10 +247,10 @@ struct compart_data_list* scan_rtld_linkmap(int pid, struct r_debug target_debug
 
 	char *path = get_string(pid, (psaddr_t)entry.linkmap.l_name, 0);
 
-	debug_print(INFO, "remote_linkmap_name: %p path: %s compart_id: %d\n", entry.linkmap.l_name, path, entry.compart_id);
+	debug_print(INFO, "remote_linkmap_name: %p path: %s default_compart_id: %d\n", entry.linkmap.l_name, path, entry.default_compart_id);
 
 	compart_data_from_linkmap data;
-	data.id = entry.compart_id;
+	data.id = entry.default_compart_id;
 	data.path = path;
 
 	struct compart_data_list *comparts_entry;

--- a/src/rtld_linkmap_scan.c
+++ b/src/rtld_linkmap_scan.c
@@ -247,10 +247,10 @@ struct compart_data_list* scan_rtld_linkmap(int pid, struct r_debug target_debug
 
 	char *path = get_string(pid, (psaddr_t)entry.linkmap.l_name, 0);
 
-	debug_print(INFO, "remote_linkmap_name: %p path: %s default_compart_id: %d\n", entry.linkmap.l_name, path, entry.default_compart_id);
+	debug_print(INFO, "remote_linkmap_name: %p path: %s compart_id: %d\n", entry.linkmap.l_name, path, entry.compart_id);
 
 	compart_data_from_linkmap data;
-	data.id = entry.default_compart_id;
+	data.id = entry.compart_id;
 	data.path = path;
 
 	struct compart_data_list *comparts_entry;


### PR DESCRIPTION
…s build system to overwrite.

Also updated the Obj_Entry.compart_id name to be default_compart_id because chericat needs to work with the dev build (which will become the main).