### PR TITLE
Support sublibrary comparts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 bin/
 src/*.o
+.depend*
+chericat
+chericat.1*
+chericat.full
+chericat.debug
 *.out
 *.db
 *.sql

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
-src/*.o
+*.o
+**/*.o
 .depend*
 chericat
 chericat.1*

--- a/Makefile
+++ b/Makefile
@@ -1,62 +1,14 @@
-BIN=./bin
-SRC=./src
-DEPS=./includes
+PROG= chericat
+MAN=  chericat.1
+SRCS= src/cap_capture.c src/caps_syms_view.c src/chericat.c src/common.c src/db_process.c src/elf_utils.c src/mem_scan.c src/ptrace_utils.c src/rtld_linkmap_scan.c src/vm_caps_view.c
 
-CC?=cc
-CFLAGS+=-g -O0
-CFLAGS+=-Wall -Wcheri
-CFLAGS+=-DIN_RTLD -DCHERI_LIB_C18N -DRTLD_SANDBOX
+PREFIX?=     /usr/local
+SRC_BASE?=   /usr/src
+ARCH?=       aarch64
+LDADD+=      -lelf -lprocstat -lsqlite3 -lxo 
 
-SRC_BASE?=/usr/src
-ARCH+=aarch64
-INC=-I/usr/include -I/usr/local/include -I$(DEPS) -I${SRC_BASE}/libexec/rtld-elf -I${SRC_BASE}/libexec/rtld-elf/${ARCH}
-LDFLAGS=-L/usr/lib -L/usr/local/lib 
+.if !defined(LOCALBASE)
+CFLAGS+=     -I${PREFIX}/include -I./includes -I${SRC_BASE}/libexec/rtld-elf -I${SRC_BASE}/libexec/rtld-elf/${ARCH} -L${PREFIX}/lib -DIN_RTLD -DCHERI_LIB_C18N
+.endif
 
-.PHONY: all
-.PHONY: make_dir
-.PHONY: clean
-
-TARGET=$(BIN)/chericat
-all: make_dir $(TARGET)
-
-make_dir: $(BIN)/
-
-$(BIN)/:
-	mkdir -p $@
-
-$(TARGET): $(SRC)/chericat.c $(BIN)/common.o $(BIN)/mem_scan.o $(BIN)/db_process.o $(BIN)/cap_capture.o $(BIN)/elf_utils.o $(BIN)/ptrace_utils.o $(BIN)/vm_caps_view.o $(BIN)/caps_syms_view.o $(BIN)/rtld_linkmap_scan.o
-	$(CC) $(CFLAGS) $(INC) $(LDFLAGS) -DSQLITE_MEMDEBUG -lelf -lprocstat -lsqlite3 -lxo -o $(TARGET) $(BIN)/common.o $(BIN)/mem_scan.o $(BIN)/elf_utils.o $(BIN)/ptrace_utils.o $(BIN)/cap_capture.o $(BIN)/db_process.o $(BIN)/vm_caps_view.o $(BIN)/caps_syms_view.o $(BIN)/rtld_linkmap_scan.o $(SRC)/chericat.c
-
-$(BIN)/common.o: $(SRC)/common.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/common.o $(SRC)/common.c
-$(BIN)/mem_scan.o: $(SRC)/mem_scan.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/mem_scan.o $(SRC)/mem_scan.c
-
-$(BIN)/ptrace_utils.o: $(SRC)/ptrace_utils.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/ptrace_utils.o $(SRC)/ptrace_utils.c
-
-$(BIN)/elf_utils.o: $(SRC)/elf_utils.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/elf_utils.o $(SRC)/elf_utils.c
-
-$(BIN)/db_process.o: $(SRC)/db_process.c $(DEPS)/db_process.h
-	$(CC) $(CFLAGS) $(INC) -DSQLITE_MEMDEBUG -c -o $(BIN)/db_process.o $(SRC)/db_process.c
-
-$(BIN)/cap_capture.o: $(SRC)/cap_capture.c $(DEPS)/cap_capture.h
-	$(CC) $(CFLAGS) $(INC) -DSQLITE_MEMDEBUG -c -o $(BIN)/cap_capture.o $(SRC)/cap_capture.c
-
-$(BIN)/vm_caps_view.o: $(SRC)/vm_caps_view.c $(DEPS)/vm_caps_view.h
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/vm_caps_view.o $(SRC)/vm_caps_view.c
-
-$(BIN)/caps_syms_view.o: $(SRC)/caps_syms_view.c $(DEPS)/caps_syms_view.h
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/caps_syms_view.o $(SRC)/caps_syms_view.c
-
-$(BIN)/rtld_linkmap_scan.o: $(SRC)/rtld_linkmap_scan.c
-	$(CC) $(CFLAGS) $(INC) -c -o $(BIN)/rtld_linkmap_scan.o $(SRC)/rtld_linkmap_scan.c
-
-TEST=./tests
-
-test: $(TEST)/db_process_test.c $(BIN)/common.o
-	$(CC) $(CFLAGS) $(INC) $(LDFLAGS) -DSQLITE_MEMDEBUG -lsqlite3 -o $(TARGET) $(BIN)/common.o $(TEST)/db_process_test.c -o $(BIN)/db_process_test
-
-clean:
-	rm -rf $(BIN)/*.o $(BIN)/chericat
+.include <bsd.prog.mk>

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROG= chericat
 MAN=  chericat.1
 .PATH: ${.CURDIR}/src
-SRCS= cap_capture.c caps_syms_view.c chericat.c common.c db_process.c elf_utils.c mem_scan.c ptrace_utils.c rtld_linkmap_scan.c vm_caps_view.c
+SRCS= cap_capture.c caps_syms_view.c chericat.c common.c db_process.c elf_utils.c mem_scan.c ptrace_utils.c rtld_linkmap_scan.c vm_caps_view.c comp_caps_view.c
 
 PREFIX?=     /usr/local
 SRC_BASE?=   /usr/src

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PROG= chericat
 MAN=  chericat.1
-SRCS= src/cap_capture.c src/caps_syms_view.c src/chericat.c src/common.c src/db_process.c src/elf_utils.c src/mem_scan.c src/ptrace_utils.c src/rtld_linkmap_scan.c src/vm_caps_view.c
+.PATH: ${.CURDIR}/src
+SRCS= cap_capture.c caps_syms_view.c chericat.c common.c db_process.c elf_utils.c mem_scan.c ptrace_utils.c rtld_linkmap_scan.c vm_caps_view.c
 
 PREFIX?=     /usr/local
 SRC_BASE?=   /usr/src

--- a/includes/common.h
+++ b/includes/common.h
@@ -45,5 +45,6 @@
 
 void set_print_level(int level);
 void debug_print(int level, const char *fmt, ...);
+void get_filename_from_path(char *path, char **filename); 
 
 #endif //COMMON_H_

--- a/includes/comp_caps_view.h
+++ b/includes/comp_caps_view.h
@@ -1,11 +1,12 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause
  *
- * Copyright (c) 2023 Capabilities Limited
+ * Copyright (c) 2023 Jessica Man 
  *
- * This software was developed by Capabilities Limited under Innovate UK
- * project 10027440, "Developing and Evaluating an Open-Source Desktop for Arm
- * Morello".
+ * This software was developed by the University of Cambridge Computer
+ * Laboratory (Department of Computer Science and Technology) as part of the
+ * CHERI for Hypervisors and Operating Systems (CHaOS) project, funded by
+ * EPSRC grant EP/V000292/1.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,37 +30,9 @@
  * SUCH DAMAGE.
  */
 
-#ifndef RTLD_LINKMAP_SCAN_H_
-#define RTLD_LINKMAP_SCAN_H_
+#ifndef COMP_CAPS_VIEW_H_
+#define COMP_CAPS_VIEW_H_
 
-#include <sqlite3.h>
-#include <stdbool.h>
+void comp_caps_view(sqlite3 *db);
 
-#include <sys/link_elf.h>
-#include <sys/param.h>
-#include <sys/queue.h>
-#include <sys/socket.h>
-#include <sys/sysctl.h>
-#include <libprocstat.h>
-
-typedef struct struct_compart_data_from_linkmap {
-    int id;
-    int names_array_size;
-    char **names_array;
-    char *path;
-    Elf_Addr start_addr;
-    Elf_Addr end_addr;
-    bool is_default;
-} compart_data_from_linkmap;
-
-typedef struct struct_compart_data_list {
-	compart_data_from_linkmap data;
-	struct struct_compart_data_list *next;
-} compart_data_list;
-
-struct r_debug get_r_debug(int pid, struct procstat *psp, struct kinfo_proc *kipp);
-void getprocs_with_procstat_sysctl(sqlite3 *db, int pid);
-compart_data_list *scan_rtld_linkmap(int pid, sqlite3 *db, struct r_debug target_debug);
-char **scan_r_comparts(int pid, sqlite3 *db, struct r_debug target_debug);
-
-#endif //RTLD_LINKMAP_SCAN_H_
+#endif //COMP_CAPS_VIEW_H_

--- a/includes/db_process.h
+++ b/includes/db_process.h
@@ -72,6 +72,16 @@ typedef struct sym_info_struct {
         char *addr; 
 } sym_info;
 
+typedef struct comp_info_struct {
+    int compart_id;
+    char *compart_name;
+    char *library_path;
+    char *start_addr;
+    char *end_addr;
+    int is_default;
+    int parent_id;
+} comp_info;
+
 char *get_dbname(); 
 int create_vm_cap_db(sqlite3 *db);
 int create_elf_sym_db(sqlite3 *db);
@@ -83,11 +93,13 @@ int commit_transaction(sqlite3 *db);
 int vm_info_count(sqlite3 *db);
 int cap_info_count(sqlite3 *db);
 int sym_info_count(sqlite3 *db);
+int comp_info_count(sqlite3 *db);
 int cap_info_for_lib_count(sqlite3 *db, char *lib);
 
 int get_all_vm_info(sqlite3 *db, vm_info **all_vm_info);
 int get_all_cap_info(sqlite3 *db, cap_info **all_cap_info);
 int get_all_sym_info(sqlite3 *db, sym_info **all_sym_info);
+int get_all_comp_info(sqlite3 *db, comp_info **all_comp_info);
 int get_cap_info_for_lib(sqlite3 *db, cap_info **cap_info_captured_ptr, char *lib);
 
 #endif //DB_PROCESS_H_

--- a/includes/ptrace_utils.h
+++ b/includes/ptrace_utils.h
@@ -33,7 +33,7 @@
 #ifndef PTRACE_UTILS_H_
 #define PTRACE_UTILS_H_
 
-#define	MAXSIZE		4096
+#define	PTRACE_READ_STRING_MAXSIZE 4096
 
 typedef uint64_t psaddr_t;	/* An address in the target process. */
 

--- a/includes/rtld_linkmap_scan.h
+++ b/includes/rtld_linkmap_scan.h
@@ -42,7 +42,7 @@
 #include <sys/sysctl.h>
 #include <libprocstat.h>
 
-typedef struct struct_compart_data_from_linkmap {
+typedef struct struct_compart_data {
     int id;
     int names_array_size;
     char **names_array;
@@ -50,10 +50,10 @@ typedef struct struct_compart_data_from_linkmap {
     Elf_Addr start_addr;
     Elf_Addr end_addr;
     bool is_default;
-} compart_data_from_linkmap;
+} compart_data;
 
 typedef struct struct_compart_data_list {
-	compart_data_from_linkmap data;
+	compart_data data;
 	struct struct_compart_data_list *next;
 } compart_data_list;
 

--- a/src/cap_capture.c
+++ b/src/cap_capture.c
@@ -30,13 +30,13 @@
  * SUCH DAMAGE.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
 
 #include <errno.h>
 #include <string.h>

--- a/src/cap_capture.c
+++ b/src/cap_capture.c
@@ -118,11 +118,11 @@ int get_tags(sqlite3 *db, int pid, u_long start, char *path)
         int retno = ptrace(PT_IO, pid, (caddr_t)&piod, 0);
 
 	// retno is 0 is the address has a cheri tag
-	// "start" is the address pointing to a page of addresses, each address is 64bytes 
-	// so there are 256 addresses on a 4k-byte page
+	// "start" is the address pointing to a page of addresses, each address is 64bits (8bytes)
+	// and there are 256 capabilities on a 4k-byte page
 	//
-	// pTrace scans the addresses per page, and stores their corresponding tag bit in the tagsbuf array,
-	// packing each 8 bits into a char, hence there are 32 chars in the tagsbuf char array.
+	// pTrace scans the capabilities per page, and stores their corresponding tag bit in the tagsbuf array,
+	// packing each 8 bits into a char, hence there are 32 bytes in the tagsbuf char array.
         if (retno == 0) {
 		char *insert_cap_query_values = NULL;
 
@@ -137,8 +137,8 @@ int get_tags(sqlite3 *db, int pid, u_long start, char *path)
 					// Checking each tag bit, if it corresponds to a capability (1) or not (0)
 					int bit = tags & 1;
 
-					// The corresponding address of each tag is offset by 8x16 from the 256 addresses we have reached 
-					// so far in this loop, because each tags in tagsbuf has 8 bits, each bit correspond to a 16 bytes address.
+					// The corresponding capabilty of each tag is offset by 8x16 from the 256 capabilities we have reached 
+					// so far in this loop, because each tags in tagsbuf has 8 bits, each bit correspond to a 16-byte capability.
 					// We need to calculate the offset from start, hence the i*8*16 to get the starting address in each 
 					// inner iteration.
 					u_long address = start + i*8*16 + j*16;

--- a/src/cap_capture.c
+++ b/src/cap_capture.c
@@ -60,7 +60,7 @@ void get_capability(int pid, void* addr, int current_cap_count, char *path, char
         piod.piod_addr = capbuf;
         piod.piod_len = sizeof(capbuf);
 	
-        // Sending IO trace request and obtain the capability pointed to by the provided address
+        // Sending IO trace request and obtain the capability
 	int retno = ptrace(PT_IO, pid, (caddr_t)&piod, 0);
 
 	if (DEBUG) {
@@ -101,8 +101,8 @@ void get_capability(int pid, void* addr, int current_cap_count, char *path, char
 
 /* get_tags
  * By using the ptrace PIOD_READ_CHERI_TAGS API, this function scans each provided
- * address - u_long start - and find all the marked tags. It stores the found tags'
- * addressed to the vm_cap_info struct along with the capabilities info obtained. 
+ * capability - u_long start - and find all the marked tags. It stores the found tags'
+ * capabilities to the vm_cap_info struct. 
  */
 int get_tags(sqlite3 *db, int pid, u_long start, char *path)
 {
@@ -117,8 +117,8 @@ int get_tags(sqlite3 *db, int pid, u_long start, char *path)
 
         int retno = ptrace(PT_IO, pid, (caddr_t)&piod, 0);
 
-	// retno is 0 is the address has a cheri tag
-	// "start" is the address pointing to a page of addresses, each address is 64bits (8bytes)
+	// retno is 0 is the capability has a cheri tag
+	// "start" is the capability pointing to a page of capabilities, each capability is 64bits (8bytes)
 	// and there are 256 capabilities on a 4k-byte page
 	//
 	// pTrace scans the capabilities per page, and stores their corresponding tag bit in the tagsbuf array,
@@ -139,7 +139,7 @@ int get_tags(sqlite3 *db, int pid, u_long start, char *path)
 
 					// The corresponding capabilty of each tag is offset by 8x16 from the 256 capabilities we have reached 
 					// so far in this loop, because each tags in tagsbuf has 8 bits, each bit correspond to a 16-byte capability.
-					// We need to calculate the offset from start, hence the i*8*16 to get the starting address in each 
+					// We need to calculate the offset from start, hence the i*8*16 to get the starting capability in each 
 					// inner iteration.
 					u_long address = start + i*8*16 + j*16;
 					tags_addr[j] = (uintptr_t)address;

--- a/src/chericat.c
+++ b/src/chericat.c
@@ -49,6 +49,7 @@
 #include "ptrace_utils.h"
 #include "rtld_linkmap_scan.h"
 #include "vm_caps_view.h"
+#include "comp_caps_view.h"
 
 sqlite3 *db = NULL;
 
@@ -209,7 +210,7 @@ int main(int argc, char **argv)
 	    xo_close_container("vm_view");
 	} else if (strcmp(argv[1], "comp") == 0) {
 	    xo_open_container("compart_view");
-	    // TODO: compart_caps_view(db);
+	    comp_caps_view(db);
 	    xo_close_container("compart_view");
 	}
     }

--- a/src/common.c
+++ b/src/common.c
@@ -31,10 +31,11 @@
  */
 
 #include <err.h>
+#include <string.h>
+
 #include "common.h"
 #include "stdio.h"
 #include "stdarg.h"
-#include <string.h>
 
 int print_level;
 

--- a/src/common.c
+++ b/src/common.c
@@ -32,11 +32,11 @@
 
 #include <err.h>
 #include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
 
 #include "common.h"
-#include "stdio.h"
-#include "stdarg.h"
-
 int print_level;
 
 void set_print_level(int level) {

--- a/src/common.c
+++ b/src/common.c
@@ -34,6 +34,7 @@
 #include "common.h"
 #include "stdio.h"
 #include "stdarg.h"
+#include <string.h>
 
 int print_level;
 
@@ -51,5 +52,16 @@ void debug_print(int level, const char *fmt, ...)
 		vfprintf(stdout, fmt, argptr);
 		va_end(argptr);
 	}
+}
+
+void get_filename_from_path(char *path, char **filename) {
+        char slash = '/';
+        char *ptr = strrchr(path, slash);
+
+        if (ptr) {
+                *filename = strdup(ptr+1); //Move pointer one to the right to not include the '/' itself
+        } else {
+                *filename = strdup(path);
+        }
 }
 

--- a/src/comp_caps_view.c
+++ b/src/comp_caps_view.c
@@ -30,15 +30,15 @@
  * SUCH DAMAGE.
  */
 
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include <sys/cdefs.h>
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <sys/user.h>
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <libxo/xo.h>
 

--- a/src/comp_caps_view.c
+++ b/src/comp_caps_view.c
@@ -1,0 +1,162 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2023 Jessica Man 
+ *
+ * This software was developed by the University of Cambridge Computer
+ * Laboratory (Department of Computer Science and Technology) as part of the
+ * CHERI for Hypervisors and Operating Systems (CHaOS) project, funded by
+ * EPSRC grant EP/V000292/1.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+
+#include <libxo/xo.h>
+
+#include "db_process.h"
+
+/*
+ * comp_caps_view
+ * SQLite callback routine to traverse results from sqlite_exec()
+ * using:
+ * 
+ * 1. "SELECT * FROM comparts;"
+ * Results are formatted into: compart_id, compart_name, start_addr, end_addr
+ *
+ * 2. "SELECT * FROM cap_info WHERE cap_loc_addr >= start_addr AND cap_loc_addr <= end_addr;"
+ * Results are added: no_of_caps(%), no_of_ro_caps, no_of_rw_caps, no_of_rx_caps, no_of_rwx_caps
+ * 
+ */
+void comp_caps_view(sqlite3 *db) 
+{
+	comp_info *comp_info_captured;
+	int comp_count = get_all_comp_info(db, &comp_info_captured);
+	assert(comp_count != -1);
+
+	cap_info *cap_info_captured;
+	int cap_count = get_all_cap_info(db, &cap_info_captured);
+	assert(cap_count != -1);
+
+	int dbname_len = strlen(get_dbname());
+	for (int l=0; l<dbname_len+4; l++) {	
+		xo_emit("{:/-}");
+	}
+	xo_emit("{:/\n %s \n}", get_dbname());
+	for (int l=0; l<dbname_len+4; l++) {	
+		xo_emit("{:/-}");
+	}
+
+	int ptrwidth = sizeof(void *);
+	xo_emit("{T:/\n%6s %27s %9s %27s %10s %5s %5s %5s %8s %8s}\n",
+		"SRC_ID", "SRC_NAME", "DEST_ID", "DEST_NAME", "ro", "rw", "rx", "rwx", "TOTAL", "DENSITY");
+		
+	xo_open_list("comp_cap_output");
+	for (int i=0; i<comp_count; i++) {
+		xo_open_instance("comp_cap_output");
+		xo_emit("{:src_compart_id/%6d}", comp_info_captured[i].compart_id);
+		xo_emit("{:src_compart_name/%28s}", comp_info_captured[i].compart_name);
+		xo_emit("{:dest_compart_id/%10d}", comp_info_captured[i].compart_id);
+		xo_emit("{:dest_compart_name/%28s}", comp_info_captured[i].compart_name);
+		uintptr_t start_addr = 0;
+		if (comp_info_captured[i].start_addr != NULL) {
+		    start_addr = (uintptr_t)strtol(comp_info_captured[i].start_addr, NULL, 0);
+	       	}
+		uintptr_t end_addr = 0;
+		if  (comp_info_captured[i].end_addr != NULL) {
+		    end_addr = (uintptr_t)strtol(comp_info_captured[i].end_addr, NULL, 0);
+		}
+
+		int out_cap_count=0;
+		int ro_count=0;
+		int rw_count=0;
+		int rx_count=0;
+		int rwx_count=0;
+
+		for (int j=0; j<cap_count; j++) {
+			uintptr_t cap_loc_addr = (uintptr_t)strtol(cap_info_captured[j].cap_loc_addr, NULL, 0);
+			uintptr_t cap_addr = (uintptr_t)strtol(cap_info_captured[j].cap_addr, NULL, 0);
+		
+			if (cap_loc_addr >= start_addr && 
+			    cap_loc_addr <= end_addr && 
+                            cap_addr >= start_addr && 
+                            cap_addr <= end_addr) {
+				out_cap_count++;
+				if (strchr(cap_info_captured[j].perms, 'r') != NULL &&
+					strchr(cap_info_captured[j].perms, 'w') == NULL &&
+					strchr(cap_info_captured[j].perms, 'x') == NULL) {
+					ro_count++;
+				}
+				if (strchr(cap_info_captured[j].perms, 'r') != NULL &&
+					strchr(cap_info_captured[j].perms, 'w') != NULL &&
+					strchr(cap_info_captured[j].perms, 'x') == NULL) {
+					rw_count++;
+				}
+				if (strchr(cap_info_captured[j].perms, 'r') != NULL &&
+					strchr(cap_info_captured[j].perms, 'x') != NULL &&
+					strchr(cap_info_captured[j].perms, 'w') == NULL) {
+					rx_count++;
+				}
+				if (strchr(cap_info_captured[j].perms, 'r') != NULL &&
+					strchr(cap_info_captured[j].perms, 'x') != NULL &&
+					strchr(cap_info_captured[j].perms, 'w') != NULL) {
+					rwx_count++;
+				}
+			}
+		}
+		xo_emit("{:ro_count/%11d} ", ro_count);
+		xo_emit("{:rw_count/%5d} ", rw_count);
+		xo_emit("{:rx_count/%5d} ", rx_count);
+		xo_emit("{:rwx_count/%5d} ", rwx_count);
+		xo_emit("{:out_cap_count/%8d} ", out_cap_count);
+
+		xo_emit("{:out_cap_density/%8.2f%%}\n", ((float)out_cap_count/cap_count)*100);
+			
+		free(comp_info_captured[i].start_addr);
+		free(comp_info_captured[i].end_addr);
+		free(comp_info_captured[i].compart_name);
+		
+		xo_close_instance("comp_cap_output");
+	}
+	for (int k=0; k<cap_count; k++) {
+		free(cap_info_captured[k].cap_loc_addr);
+		free(cap_info_captured[k].cap_addr);
+		free(cap_info_captured[k].perms);
+		free(cap_info_captured[k].base);
+		free(cap_info_captured[k].top);
+	}
+	
+	xo_close_list("comp_cap_output");
+	free(comp_info_captured);
+	free(cap_info_captured);
+
+}
+

--- a/src/comp_caps_view.c
+++ b/src/comp_caps_view.c
@@ -76,16 +76,16 @@ void comp_caps_view(sqlite3 *db)
 	}
 
 	int ptrwidth = sizeof(void *);
-	xo_emit("{T:/\n%6s %27s %9s %27s %10s %5s %5s %5s %8s %8s}\n",
-		"SRC_ID", "SRC_NAME", "DEST_ID", "DEST_NAME", "ro", "rw", "rx", "rwx", "TOTAL", "DENSITY");
+	xo_emit("{T:/\n%6s %44s %9s %44s %10s %5s %5s %5s %8s %8s}\n",
+		"COMP_ID", "CAPLOC_COMP_NAME", "COMP_ID", "CAPADDR_COMP_NAME", "ro", "rw", "rx", "rwx", "TOTAL", "DENSITY");
 		
 	xo_open_list("comp_cap_output");
 	for (int i=0; i<comp_count; i++) {
 		xo_open_instance("comp_cap_output");
 		xo_emit("{:src_compart_id/%6d}", comp_info_captured[i].compart_id);
-		xo_emit("{:src_compart_name/%28s}", comp_info_captured[i].compart_name);
+		xo_emit("{:src_compart_name/%45s}", comp_info_captured[i].compart_name);
 		xo_emit("{:dest_compart_id/%10d}", comp_info_captured[i].compart_id);
-		xo_emit("{:dest_compart_name/%28s}", comp_info_captured[i].compart_name);
+		xo_emit("{:dest_compart_name/%45s}", comp_info_captured[i].compart_name);
 		uintptr_t start_addr = 0;
 		if (comp_info_captured[i].start_addr != NULL) {
 		    start_addr = (uintptr_t)strtol(comp_info_captured[i].start_addr, NULL, 0);

--- a/src/db_process.c
+++ b/src/db_process.c
@@ -450,6 +450,8 @@ int vm_info_count(sqlite3 *db)
         char *count;
         sql_query_exec(db, "SELECT COUNT(*) FROM vm;", info_count_query_callback, &count);
 	int result_count = convert_str_to_int(count, "Query to get count from vm returned an invalid value");
+	debug_print(INFO, "vm_info_count_query returned %d\n", result_count);
+
 	free(count);
 	return result_count;
 }

--- a/src/db_process.c
+++ b/src/db_process.c
@@ -30,6 +30,10 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/ptrace.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,10 +41,6 @@
 #include <errno.h>
 #include <string.h>
 #include <sqlite3.h>
-
-#include <sys/ptrace.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 
 #include <cheri/cheric.h>
 

--- a/src/mem_scan.c
+++ b/src/mem_scan.c
@@ -200,7 +200,7 @@ void scan_mem(sqlite3 *db, int pid)
 				} else if (kivp->kve_flags & KVME_FLAG_GROWS_DOWN) {
 					mmap_path = strdup("Stack");
 				} else {
-					mmap_path = strdup("unknown");
+					mmap_path = strdup("Heap(others)");
 				}
 			}
 		} else {
@@ -222,56 +222,18 @@ void scan_mem(sqlite3 *db, int pid)
 			free(new_path);
 		}
 
-		compart_data_list *head = scanned_comparts;
+		compart_data_list *comparts_head = scanned_comparts;
 
 		int compart_id = -1;
 
-		while (head != NULL) {
-			compart_data_from_linkmap compart_data = head->data;
-			if ((compart_data.path != NULL) && strncmp(compart_data.path, mmap_path, strlen(compart_data.path)) == 0) {
-				compart_id = compart_data.id;
+		while (comparts_head != NULL) {
+			compart_data current_compart_data = comparts_head->data;
+			if ((current_compart_data.path != NULL) && strncmp(current_compart_data.path, mmap_path, strlen(current_compart_data.path)) == 0) {
+				compart_id = current_compart_data.id;
 				break;
 			}
-
-			/*
-			// Given that the rtld itself is not assigned a compartment, it is 
-			// assigned a special value of -2 so that it can be used to separate
-			// from the unknowns, which are given a compart_id of -1.
-			int is_substring = _is_substring_of("ld-elf", mmap_path);
-			if (is_substring != -1) {
-				compart_id = -2;
-				break;
-			}
-			// Guard pages have no compartmentalisational value in chericat, hence 
-			// separating them by assigning it a special value of -3.
-			if (strcmp("Guard", mmap_path) == 0) {
-				compart_id = -3;
-			}*/
-			head = head->next;
+			comparts_head = comparts_head->next;
 		}
-
-		/*
-		if (strcmp("Stack", mmap_path) == 0) {
-			// At the bottom of the stack, i.e. the top limit bound of the stack capability
-			// the offset -32 bytes are the struct stk_bottom data, which contains the 
-			// compart_id for the stack
-			// Therefore we need to use ptrace to scan for the address (kve_end - 0x20) 
-			// in order to obtain the struct stk_bottom data
-			ptrace_attach(pid);
-
-			//struct stk_bottom stack_compart_data = calloc(sizeof(struct stk_bottom), 1);
-			struct stk_bottom stack_compart_data;
-			void *stk_bottom_addr = (void*)(kivp->kve_end - 0x20);
-			piod_read(pid, PIOD_READ_D, stk_bottom_addr, &stack_compart_data, sizeof(struct stk_bottom));
-			debug_print(INFO, "remote_stack_bottom: %p local_stack_compart_data: %p compart_id for this stack: %d\n", stk_bottom_addr, stack_compart_data, stack_compart_data.compart_id); 
-				
-			compart_id = stack_compart_data.compart_id;
-			
-			ptrace_detach(pid);
-		}
-		*/
-
-		//free(head);
 
 		debug_print(INFO, "0x%016lx 0x%016lx %s %d %d %d %d\n", 
                         kivp->kve_start,

--- a/src/mem_scan.c
+++ b/src/mem_scan.c
@@ -30,6 +30,15 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <sys/ptrace.h>
+#include <sys/user.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -39,19 +48,9 @@
 #include <string.h>
 #include <sqlite3.h>
 #include <time.h>
-
-#include <sys/param.h>
-#include <sys/queue.h>
-#include <sys/socket.h>
-#include <sys/sysctl.h>
 #include <libprocstat.h>
 
 #include <libxo/xo.h>
-#include <sys/ptrace.h>
-#include <sys/user.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-
 #include <cheri/cheric.h>
 
 #include "mem_scan.h"

--- a/src/ptrace_utils.c
+++ b/src/ptrace_utils.c
@@ -30,6 +30,14 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <sys/ptrace.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,15 +50,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-#include <sys/param.h>
-#include <sys/queue.h>
-#include <sys/socket.h>
-#include <sys/sysctl.h>
 #include <libprocstat.h>
-
-#include <sys/ptrace.h>
-#include <sys/user.h>
-#include <sys/wait.h>
 
 #include "common.h"
 #include "db_process.h"

--- a/src/ptrace_utils.c
+++ b/src/ptrace_utils.c
@@ -210,8 +210,8 @@ get_string(pid_t pid, psaddr_t addr, int max)
 	else {
 		/* Read up to the end of the current page. */
 		size = PAGE_SIZE - (addr % PAGE_SIZE);
-		if (size > MAXSIZE)
-			size = MAXSIZE;
+		if (size > PTRACE_READ_STRING_MAXSIZE)
+			size = PTRACE_READ_STRING_MAXSIZE;
 	}
 	totalsize = size;
 	buf = malloc(totalsize);
@@ -229,8 +229,8 @@ get_string(pid_t pid, psaddr_t addr, int max)
 		if (memchr(buf + offset, '\0', size) != NULL)
 			return (buf);
 		offset += size;
-		if (totalsize < MAXSIZE && max == 0) {
-			size = MAXSIZE - totalsize;
+		if (totalsize < PTRACE_READ_STRING_MAXSIZE && max == 0) {
+			size = PTRACE_READ_STRING_MAXSIZE - totalsize;
 			if (size > PAGE_SIZE)
 				size = PAGE_SIZE;
 			nbuf = realloc(buf, totalsize + size);

--- a/src/rtld_linkmap_scan.c
+++ b/src/rtld_linkmap_scan.c
@@ -45,16 +45,17 @@
 #include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
-#include <libprocstat.h>
 
 #include <libxo/xo.h>
+#include <libprocstat.h>
 #include <sys/ptrace.h>
 
 #include "common.h"
+#include "db_process.h"
 #include "ptrace_utils.h"
 #include "rtld_linkmap_scan.h"
 
-/* Copied from rtld-elf/rtld_c18n.c */
+/* START Copied from rtld-elf/rtld_c18n.c */
 typedef ssize_t string_handle;
 
 struct string_base {
@@ -64,6 +65,10 @@ struct string_base {
 };
 
 typedef struct compart {
+    /*
+     * Compartment information exposed to the kernel.
+     */
+    struct rtld_c18n_compart info;
     /*
      * Name of the compartment
      */
@@ -83,15 +88,15 @@ typedef struct compart {
     struct string_base trusts;
     bool restrict_imports;
 } compart_t;
+/* END Copied section */
 
-void getprocs_with_procstat_sysctl(sqlite3 *db, char* arg_pid) 
+void getprocs_with_procstat_sysctl(sqlite3 *db, int pid) 
 {
 	struct procstat *psp;
 	struct kinfo_proc *kipp;
 	psp = procstat_open_sysctl();
 	assert(psp != NULL);
 
-	int pid = atoi(arg_pid);
         unsigned int pcnt;
 
 	kipp = procstat_getprocs(psp, KERN_PROC_PID, pid, &pcnt);
@@ -102,8 +107,17 @@ void getprocs_with_procstat_sysctl(sqlite3 *db, char* arg_pid)
 		err(1, "procstat did not get expected result from process %d, instead of a process count of 1, it got %d", pid, pcnt);
 	}
 
-	struct r_debug obtained_r_debug = get_r_debug(pid, psp, kipp);
-	scan_rtld_linkmap(pid, obtained_r_debug);
+	/* These calls are currently made as part of the scan_mem routine
+           because we are storing the compart_ids on the VM table as well
+           as the comparts table. The reason for doing that is because 
+           we cannot rely on the mapbase + mapsize from Obj_Entry structure
+           to figure out the address ranges for each compartments, as some 
+           of them might not have been initialised when the Obj_Entry is 
+           created. Once we know how to deal with this problem we can remove 
+           the calls from scan_mem and only make them here when users choose 
+           the "show comp" command line option */
+	//struct r_debug obtained_r_debug = get_r_debug(pid, psp, kipp);
+	//scan_rtld_linkmap(pid, db, obtained_r_debug);
 
 	if (kipp != NULL) {
 		procstat_freeprocs(psp, kipp);
@@ -201,15 +215,11 @@ struct r_debug get_r_debug(int pid, struct procstat *psp, struct kinfo_proc *kip
     // we are looking for.
 
     struct r_debug local_debug;
-    printf("local_debug just been created: %#p and the size of struct is %lu\n", &local_debug, sizeof(struct r_debug));
-
     piod_read(pid, PIOD_READ_D, remote_debug, (void*)&local_debug, sizeof(struct r_debug));
 
     ptrace_detach(pid);
     free(target_phdr);
     free(target_dyn);
-    free(dyn);
-    free(remote_debug);
 
     if (auxv != NULL) {
 	procstat_freeauxv(psp, auxv);
@@ -221,22 +231,12 @@ struct r_debug get_r_debug(int pid, struct procstat *psp, struct kinfo_proc *kip
  * Using the linkmap exposed via r_debug, we can get the list of mapped libraries and their 
  * corresponding compart_id.
  */
-struct compart_data_list* scan_rtld_linkmap(int pid, struct r_debug target_debug)
+compart_data_list *scan_rtld_linkmap(int pid, sqlite3 *db, struct r_debug target_debug)
 {
     ptrace_attach(pid);
 
     struct link_map *r_map = target_debug.r_map;
-    //void *linkmap_addr = __containerof(r_map, Obj_Entry, linkmap);
-    //Obj_Entry target_obj_entry; 
-    //piod_read(pid, PIOD_READ_D, linkmap_addr, &target_obj_entry, sizeof(Obj_Entry));
-    //debug_print(INFO, "remote_obj_entry: %p local_obj_entry: %p\n", linkmap_addr, target_obj_entry);
-
-    // target_link_map is a linked list, we need to traverse the entries by following l_next and look up the 
-    // Obj_Entry data in the target process for each l_addr
-    // We can now fill in the compart data structure to return.	
-    //Obj_Entry entry = target_obj_entry;
-
-    struct compart_data_list *comparts_head = NULL;
+    compart_data_list *comparts_head = NULL;
 
     while (r_map != NULL) {
 
@@ -247,18 +247,58 @@ struct compart_data_list* scan_rtld_linkmap(int pid, struct r_debug target_debug
 
 	char *path = get_string(pid, (psaddr_t)entry.linkmap.l_name, 0);
 
-	debug_print(INFO, "remote_linkmap_name: %p path: %s compart_id: %d\n", entry.linkmap.l_name, path, entry.compart_id);
+	debug_print(INFO, "remote_linkmap_name: %p path: %s default_compart_id: %d\n", entry.linkmap.l_name, path, entry.default_compart_id);
 
 	compart_data_from_linkmap data;
-	data.id = entry.compart_id;
+	data.id = entry.default_compart_id;
 	data.path = path;
+	data.is_default = true;
 
-	struct compart_data_list *comparts_entry;
-	comparts_entry = (struct compart_data_list*)malloc(sizeof(struct compart_data_list));
+	compart_data_list *comparts_entry;
+	comparts_entry = (compart_data_list*)malloc(sizeof(compart_data_list));
 	comparts_entry->data = data;
 	comparts_entry->next = comparts_head;
 	comparts_head = comparts_entry;
-		
+
+	char *insert_default_compart_q;
+	asprintf(&insert_default_compart_q, "INSERT OR REPLACE INTO comparts(compart_id, library_path, is_default) VALUES (%d, \"%s\", %d);", data.id, data.path, data.is_default);
+	sql_query_exec(db, insert_default_compart_q, NULL, NULL);
+	free(insert_default_compart_q);
+	
+	// If there are sub-compartments, create them too and add them to the list
+	if (entry.ncomparts > 0) {
+	    Compart_Entry current_subcompart;
+	    void *subcompart_addr = entry.comparts;
+
+	    for (int i=0; i<entry.ncomparts; i++) {
+		// Found a sub-compartment, construct an entry and then add to the list
+		piod_read(pid, PIOD_READ_D, subcompart_addr, &current_subcompart, sizeof(Compart_Entry));
+
+		char *compart_name = get_string(pid, (psaddr_t)current_subcompart.compart_name, 0);
+
+		compart_data_from_linkmap subcompart_data;
+                subcompart_data.id = current_subcompart.compart_id;
+		subcompart_data.start_addr = current_subcompart.start;
+                subcompart_data.end_addr = current_subcompart.end;
+                subcompart_data.is_default = false;
+
+		compart_data_list *subcompart_entry;
+		subcompart_entry = (compart_data_list*)malloc(sizeof(compart_data_list));
+		subcompart_entry->data = subcompart_data;
+		subcompart_entry->next = comparts_head;
+		comparts_head = subcompart_entry;
+
+		debug_print(INFO, "Found subcompartment with id %d and start_addr %lx\n", subcompart_data.id, subcompart_data.start_addr);
+
+		char *insert_subcomparts_q;
+		asprintf(&insert_subcomparts_q, "INSERT OR REPLACE INTO comparts(compart_id, compart_name, start_addr, end_addr, is_default, parent_id) VALUES (%d, \"%s\", \"0x%lx\", \"0x%lx\", %d, %d);", current_subcompart.compart_id, compart_name, current_subcompart.start, current_subcompart.end, false, data.id);
+		sql_query_exec(db, insert_subcomparts_q, NULL, NULL);
+		free(insert_subcomparts_q);
+		free(compart_name);
+
+		subcompart_addr = subcompart_addr + (sizeof(Compart_Entry));
+	    }
+	}
         // Ready to move to the next link_map
 	r_map = entry.linkmap.l_next;
     }
@@ -273,11 +313,11 @@ struct compart_data_list* scan_rtld_linkmap(int pid, struct r_debug target_debug
  * Using the r_comparts array exposed via r_debug, we can obtain the list of 
  * compartments names and their ids.
  */
-char **scan_r_comparts(int pid, struct r_debug target_debug)
+char **scan_r_comparts(int pid, sqlite3 *db, struct r_debug target_debug)
 {
     ptrace_attach(pid);
 
-    // This is extracting the compartments data from 
+    // In gdb, this is how the same data is extracted: 
     // ((struct compart *)r_debug->r_comparts)[r_debug->r_comparts_size]
 
     int comparts_size = target_debug.r_comparts_size;
@@ -292,15 +332,22 @@ char **scan_r_comparts(int pid, struct r_debug target_debug)
     for (int i=0; i<comparts_size; i++) {
 	compart_t *comparts_entry;
 	piod_read(pid, PIOD_READ_D, comparts, &comparts_entry, sizeof(void*));
-	debug_print(INFO, "remote_comparts: %p local_comparts_entry: %p\n", comparts, comparts_entry);
+	debug_print(INFO, "remote_comparts: %p\n", comparts);
 	
 	comparts = comparts + sizeof(compart_t);
 
-	//char *name = calloc(sizeof(char), 50);
-	//piod_read(pid, PIOD_READ_D, comparts_entry, name, sizeof(char)*50);
 	char *name = get_string(pid, (psaddr_t)comparts_entry, 0);
-	debug_print(INFO, "remote_comparts_entry: %p obtained compartment name: %s\n", comparts_entry, name);
-	
+	debug_print(INFO, "i: %d remote_comparts_entry: %p obtained compartment name: %s\n", i, comparts_entry, name);
+
+        if (name != NULL) {
+	    char *insert_comparts_db_table_q;
+	    asprintf(&insert_comparts_db_table_q, 
+		"UPDATE comparts SET "
+		"compart_name=\"%s\" "
+                "WHERE compart_id=%d;", name, i);
+	    sql_query_exec(db, insert_comparts_db_table_q, NULL, NULL);
+	    free(insert_comparts_db_table_q);
+	}
 	compart_names[i] = name;
     }
 

--- a/src/rtld_linkmap_scan.c
+++ b/src/rtld_linkmap_scan.c
@@ -247,10 +247,10 @@ struct compart_data_list* scan_rtld_linkmap(int pid, struct r_debug target_debug
 
 	char *path = get_string(pid, (psaddr_t)entry.linkmap.l_name, 0);
 
-	debug_print(INFO, "remote_linkmap_name: %p path: %s compart_id: %d\n", entry.linkmap.l_name, path, entry.compart_id);
+	debug_print(INFO, "remote_linkmap_name: %p path: %s default_compart_id: %d\n", entry.linkmap.l_name, path, entry.default_compart_id);
 
 	compart_data_from_linkmap data;
-	data.id = entry.compart_id;
+	data.id = entry.default_compart_id;
 	data.path = path;
 
 	struct compart_data_list *comparts_entry;

--- a/src/rtld_linkmap_scan.c
+++ b/src/rtld_linkmap_scan.c
@@ -247,10 +247,10 @@ struct compart_data_list* scan_rtld_linkmap(int pid, struct r_debug target_debug
 
 	char *path = get_string(pid, (psaddr_t)entry.linkmap.l_name, 0);
 
-	debug_print(INFO, "remote_linkmap_name: %p path: %s default_compart_id: %d\n", entry.linkmap.l_name, path, entry.default_compart_id);
+	debug_print(INFO, "remote_linkmap_name: %p path: %s compart_id: %d\n", entry.linkmap.l_name, path, entry.compart_id);
 
 	compart_data_from_linkmap data;
-	data.id = entry.default_compart_id;
+	data.id = entry.compart_id;
 	data.path = path;
 
 	struct compart_data_list *comparts_entry;

--- a/src/rtld_linkmap_scan.c
+++ b/src/rtld_linkmap_scan.c
@@ -29,6 +29,12 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <sys/ptrace.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -41,14 +47,8 @@
 #include <unistd.h>
 #include <rtld.h>
 
-#include <sys/param.h>
-#include <sys/queue.h>
-#include <sys/socket.h>
-#include <sys/sysctl.h>
-
 #include <libxo/xo.h>
 #include <libprocstat.h>
-#include <sys/ptrace.h>
 
 #include "common.h"
 #include "db_process.h"

--- a/src/vm_caps_view.c
+++ b/src/vm_caps_view.c
@@ -42,18 +42,8 @@
 
 #include <libxo/xo.h>
 
+#include "common.h"
 #include "db_process.h"
-
-static void get_filename_from_path(char *path, char **filename) {
-        char slash = '/';
-        char *ptr = strrchr(path, slash);
-
-        if (ptr) {
-                *filename = strdup(ptr+1); //Move pointer one to the right to not include the '/' itself
-        } else {
-                *filename = strdup(path);
-        }
-}
 
 /*
  * vm_caps_view
@@ -91,7 +81,7 @@ void vm_caps_view(sqlite3 *db)
 		ptrwidth, "START", ptrwidth-1, "END", "PRT", "ro", "rw", "rx", "rwx", "TOTAL", "DENSITY", "FLAGS", "TP", "COMPART", "PATH");
 		
 	xo_open_list("vm_cap_output");
-	for (int i=1; i<vm_count; i++) {
+	for (int i=0; i<vm_count; i++) {
 		xo_open_instance("vm_cap_output");
 		xo_emit("{:mmap_start_addr/%*s}", ptrwidth, vm_info_captured[i].start_addr);
 		xo_emit("{:mmap_end_addr/%*s}", ptrwidth, vm_info_captured[i].end_addr);

--- a/src/vm_caps_view.c
+++ b/src/vm_caps_view.c
@@ -30,15 +30,15 @@
  * SUCH DAMAGE.
  */
 
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include <sys/cdefs.h>
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <sys/user.h>
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <libxo/xo.h>
 


### PR DESCRIPTION
Added a new compartment view to the CLI that shows the caps count between compartments by issuing the following command:

`chericat -f <db> -p <pid> -v show comp`

The output table have 10 columns: 
Leftmost "COMP_ID" is the compartment ID for the source compartment, i.e. where the capabilities are located; 
"CAPLOC_COMP_NAME" is the name of the source compartment; 
Second "COMP_ID" is the compartment ID for the destination compartment, i.e. where the capability address points to; 
"CAPADD_COMP_NAME" is the name of the destination compartment; 
"ro", "rw", "rx", "rwx" are the number of capabilities found between the source and destination compartment that have those permissions respectively; 
"TOTAL" is the total number of capabilities found between the source and destination compartments; 
"DENSITY" is the percentage of the capabilities found between the source and destination compartments over the grand total of capabilities found.

Also refactored to tidy up a few C files and removed unused/commented out code. 